### PR TITLE
FE: remove scores from Search Property endpoint request + tests

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -8,9 +8,9 @@ class DashboardController < ApplicationController
       flash[:error] = "You must be logged in to view this page"
     end
 
-    if params[:user_id] && params[:property_id]
-      @property = SavedFacade.new(params[:user_id], params[:property_id]).property
-    end
+    # if params[:user_id] && params[:property_id]
+    #   @property = SavedFacade.new(params[:user_id], params[:property_id]).property
+    # end
 
     if params[:search_street] && params[:search_zip]
       @property = SearchFacade.new(params[:search_street], params[:search_zip]).property

--- a/app/facades/search_facade.rb
+++ b/app/facades/search_facade.rb
@@ -6,8 +6,8 @@ class SearchFacade
   end
 
   def property
-    return SearchError.new if @street.count("a-zA-Z") == 0  
-    
+    return SearchError.new if @street.count("a-zA-Z").zero?
+
     property ||= service.get_property(@street, @zip)
     if property[:data].nil?
       SearchError.new
@@ -22,10 +22,6 @@ class SearchFacade
     {
       street: property[:data][:attributes][:street],
       zip: property[:data][:attributes][:zip],
-      bike_score: property[:data][:attributes][:bike_score],
-      walk_score: property[:data][:attributes][:walk_score],
-      safety_score: property[:data][:attributes][:safety_score],
-      transit_score: property[:data][:attributes][:transit_score],
       city: property[:data][:attributes][:city],
       state: property[:data][:attributes][:state],
       id: property[:data][:id]

--- a/spec/facades/search_facade_spec.rb
+++ b/spec/facades/search_facade_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SearchFacade do
      'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
      'User-Agent'=>'Faraday v2.7.5'
       })
-    .to_return(status: 200, body: File.read('./spec/fixtures/property_1.json'))
+    .to_return(status: 200, body: File.read('./spec/fixtures/search_property_1.json'))
   end
   describe 'instance methods' do
     it '#property' do
@@ -19,10 +19,6 @@ RSpec.describe SearchFacade do
       expect(property).to be_a(Property)
       expect(property.street).to eq('123 Main Street')
       expect(property.zip).to eq('19148')
-      expect(property.bike_score).to eq('26')
-      expect(property.walk_score).to eq('89')
-      expect(property.transit_score).to eq('57')
-      expect(property.safety_score).to eq('93')
       expect(property.city).to eq('Philadelphia')
       expect(property.state).to eq('PA')
     end

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'dashboard show page' do
       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       'User-Agent'=>'Faraday v2.7.5'
         })
-      .to_return(status: 200, body: File.read('./spec/fixtures/property_1.json'))
+      .to_return(status: 200, body: File.read('./spec/fixtures/search_property_1.json'))
 
       stub_request(:get, 'https://sheltered-harbor-92742.herokuapp.com/api/v0/user_properties?user_id=420')
       .with(
@@ -258,7 +258,7 @@ RSpec.describe 'dashboard show page' do
       'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
       'User-Agent'=>'Faraday v2.7.5'
         })
-      .to_return(status: 200, body: File.read('./spec/fixtures/property_1.json'))
+      .to_return(status: 200, body: File.read('./spec/fixtures/search_property_1.json'))
     end
 
     it 'redirects to home page if not logged in' do

--- a/spec/fixtures/search_property_1.json
+++ b/spec/fixtures/search_property_1.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "type": "property",
+    "id": "1",
+    "attributes": {
+      "street": "123 Main Street",
+      "city": "Philadelphia",
+      "state": "PA",
+      "zip": "19148"
+    }
+  }
+}

--- a/spec/fixtures/search_property_2.json
+++ b/spec/fixtures/search_property_2.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "type": "property",
+    "id": "2",
+    "attributes": {
+      "street": "456 Center Street",
+      "city": "Philadelphia",
+      "state": "PA",
+      "zip": "19148"
+    }
+  }
+}


### PR DESCRIPTION
## Changes
- This PR closes #52 
- Adds two new mocked JSON responses for property search results
- Updates Search Facade format property method to remove scores
- Removes logic for getting property details in Dashboard show controller action - now handled in Property show action
- Updates tests

## Type of Changes
- [ ] new feature
- [ ] setup
- [x] chore
- [ ] bug fix
- [x] refactor
- [ ] other: 

## Checklist
- [ ] Tests added for new functionality
- [x] All other tests are also passing (please note if not) 
  - Current coverage %: 98.5% -- tests updated to reflect changes, but no new tests added

## Number of reviewers
- [x] 1
- [ ] 2
- [ ] 3

## Emoji or GIF about how you feel rn (optional)

