### PR TITLE
fix: update view with lat and lon variables for map

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -278,7 +278,6 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    vcr (6.1.0)
     version_gem (1.1.2)
     web-console (4.2.0)
       actionview (>= 6.0.0)
@@ -327,7 +326,6 @@ DEPENDENCIES
   tailwindcss-rails
   turbo-rails
   tzinfo-data
-  vcr
   web-console
   webmock
 

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -11,7 +11,7 @@
   <div class='flex flex-row'>
     <div id='Map' class='flex flex-col align-self: center'>
       <p>Map</p>
-      <%= image_tag map(39.92459089291047, -75.16204921093596) %>
+      <%= image_tag map(@property.lat, @property.lon) %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Changes
- This PR fixes the Properties/Show view to include dynamic lat lon variables, to replace the hard-coded lat/lon we used to set up the map functionality before adjusting the BE endpoint to pass lat / lon in the JSON response.

## Type of Changes
- [ ] new feature
- [ ] setup
- [x] chore
- [ ] bug fix
- [ ] refactor
- [ ] other: 

## Checklist
- [ ] Tests added for new functionality
- [x] All other tests are also passing (please note if not) 
  - Current coverage %: 98.5%

## Number of reviewers
- [x] 1
- [ ] 2
- [ ] 3

## Emoji or GIF about how you feel rn (optional)

