### PR TITLE
Add Nearby Parks to Property Show Page + Minor Styling Changes

### DIFF
--- a/app/facades/saved_facade.rb
+++ b/app/facades/saved_facade.rb
@@ -26,7 +26,8 @@ class SavedFacade
         state: property[:data][:attributes][:state],
         lat: property[:data][:attributes][:lat],
         lon: property[:data][:attributes][:lon],
-        id: property[:data][:id]
+        id: property[:data][:id],
+        parks: property[:data][:attributes][:parks]
       }
 
       end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,14 @@ module ApplicationHelper
   end
 
   def map(lat, lon)
-    "https://www.mapquestapi.com/staticmap/v5/map?locations=#{lat}, #{lon}&size=400, 400&zoom=12&center=#{lat}, #{lon}&key=#{ENV['MAPQUEST_KEY']}"
+    "https://www.mapquestapi.com/staticmap/v5/map?locations=#{lat}, #{lon}&size=400, 400&zoom=12&center=#{lat}, #{lon}&defaultMarker=marker-lg-1D4ED8&key=#{ENV['MAPQUEST_KEY']}"
+  end
+
+  def format_parks(parks)
+    return [{ name: 'No parks found.', street: '' }] if parks.empty?
+
+    [{ name: parks[:park_1_name], street: parks[:park_1_street] },
+     { name: parks[:park_2_name], street: parks[:park_2_street] },
+     { name: parks[:park_3_name], street: parks[:park_3_street] }]
   end
 end

--- a/app/poros/property.rb
+++ b/app/poros/property.rb
@@ -9,7 +9,8 @@ class Property
                :state,
                :lat,
                :lon,
-               :id
+               :id,
+               :parks
 
   def initialize(data)
     @street = data[:street]
@@ -23,5 +24,6 @@ class Property
     @lat = data[:lat]
     @lon = data[:lon]
     @id = data[:id]
+    @parks = data[:parks]
   end
 end

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -9,12 +9,31 @@
   </div>
 
   <div class='flex flex-row my-2'>
-    <div id='Map' class='border border-gray-400 p-2 rounded-md flex flex-col align-self: center'>
+    <div id='Map' class='p-2 flex flex-col w-1/2 align-self: center justify-center'>
       <%= image_tag(map(@property.lat, @property.lon), alt: 'Map') %>
     </div>
 
-    <div id='Nearby' class='border border-gray-400 p-2 rounded-md flex flex-grow'>
-      Nearby places will go here
+    <div id='Parks' class='border border-gray-400 p-2 rounded-md flex flex-col w-1/2 justify-center'>
+      <div class='text-lg font-bold text-center pb-10'>
+        <p>Nearby Parks</p>
+      </div>
+
+      <div class='text-center'>
+        <% format_parks(@property.parks).each do |park| %>
+          <div class='font-bold text-md pt-2 pb-1'>
+            <%= park[:name] %>
+          </div>
+          <div class='text-sm pb-2'>
+            <%= park[:street] %>
+          </div>
+        <% end %>
+
+        <div class='text-sm pt-10 px-2'>
+          <p>
+            To find more parks, activites, and green spaces near this address, visit the Parks & Recreation <a class='text-xs text-blue-700 underline hover:text-blue-900' href='https://www.phila.gov/parks-rec-finder/#/locations'>Park Finder</a>.
+          </p>
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -7,14 +7,14 @@
         </div>
         <div class="text-md">
           We provide you with code-compliant properties so you can focus on finding the best home for you.
-        </div> 
-      </div> 
+        </div>
+      </div>
       <div>
         <div id="Signup1" class="relative z-40 inline-block w-40 h-9 px-4 py-3 text-sm font-bold leading-none text-white text-center transition-all duration-300 bg-blue-700 rounded shadow-md fold-bold border-2 border-blue-700 hover:bg-white hover:text-blue-700">
           <a href="/sign_up">Sign up</a>
         </div>
       </div>
-    </div> 
+    </div>
     <div id="Image_one" class="w-1/2">
       <img src="https://images.unsplash.com/photo-1559338391-e14b84a22772?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=774&q=80">
     </div>
@@ -31,15 +31,15 @@
           <img class="object-cover w-full h-full" src="https://images.unsplash.com/photo-1484154218962-a197022b5858?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=874&q=80">
         </div>
         <div class="text-base text-center">
-          Smoke Detectors? 
-        </div>  
+          Up to building code?
+        </div>
       </div>
       <div id="mid_page_pic2" class="flex flex-col gap-6">
       <div style="width: 350px; height: 250px">
           <img class="object-cover  w-full h-full" src="https://images.unsplash.com/photo-1597026405082-eda9beae7513?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=774&q=80">
           </div>
         <div class="text-base text-center">
-          Safe neighborhood? 
+          Safe neighborhood?
         </div>
       </div>
       <div id="mid_page_pic3" class="flex flex-col gap-6">
@@ -47,7 +47,7 @@
           <img class="object-cover  w-full h-full" src="https://images.unsplash.com/photo-1584278140365-2ab8bff2be82?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=870&q=80">
           </div>
         <div class="text-base text-center">
-          Lifestyle fit? 
+          Lifestyle fit?
         </div>
       </div>
     </div>

--- a/spec/facades/saved_facade_spec.rb
+++ b/spec/facades/saved_facade_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe SavedFacade do
     it '#property' do
       facade = SavedFacade.new('5', '1')
       property = facade.property
-
       expect(property).to be_a(Property)
       expect(property.street).to eq('123 Main Street')
       expect(property.zip).to eq('19148')
@@ -27,6 +26,14 @@ RSpec.describe SavedFacade do
       expect(property.state).to eq('PA')
       expect(property.lat).to eq('39.96246')
       expect(property.lon).to eq('-75.13755')
+      expect(property.parks).to be_a(Hash)
+
+      parks = property.parks
+      keys = %i[park_1_name park_1_street park_2_name park_2_street park_3_name park_3_street]
+      keys.each do |key|
+        expect(parks).to have_key(key)
+        expect(parks[key]).to be_a(String)
+      end
     end
   end
 end

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -117,6 +117,8 @@ RSpec.describe 'dashboard show page' do
       within '#property-2' do
         click_button 'More Details'
         expect(current_path).to eq(property_path(420, 2))
+        save_and_open_page
+
       end
 
       within '#Result' do

--- a/spec/features/dashboard/show_spec.rb
+++ b/spec/features/dashboard/show_spec.rb
@@ -117,8 +117,6 @@ RSpec.describe 'dashboard show page' do
       within '#property-2' do
         click_button 'More Details'
         expect(current_path).to eq(property_path(420, 2))
-        save_and_open_page
-
       end
 
       within '#Result' do

--- a/spec/features/properties/show_spec.rb
+++ b/spec/features/properties/show_spec.rb
@@ -78,5 +78,19 @@ RSpec.describe 'property show page' do
     #     expect(page).to have_css(".img")
     #   end
     # end
+
+    it 'displays nearby parks' do
+      visit property_path(@user.id, 1)
+
+      within '#Parks' do
+        expect(page).to have_content('Nearby Parks')
+        expect(page).to have_content('Test 1')
+        expect(page).to have_content('Test 1 Street')
+        expect(page).to have_content('Test 2')
+        expect(page).to have_content('Test 2 Street')
+        expect(page).to have_content('Test 3')
+        expect(page).to have_content('Test 3 Street')
+      end
+    end
   end
 end

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "landing page" do
   it 'has mid page content' do
    within "#mid_page" do
     expect(page).to have_content("Sometimes pictures aren't enough")
-    expect(page).to have_content("Smoke Detectors?")
+    expect(page).to have_content("Up to building code?")
     expect(page).to have_content("Safe neighborhood?")
     expect(page).to have_content("Lifestyle fit?")
    end

--- a/spec/fixtures/property_1.json
+++ b/spec/fixtures/property_1.json
@@ -12,7 +12,15 @@
       "bike_score": "26",
       "safety_score": "93",
       "lat": "39.96246",
-      "lon": "-75.13755"
+      "lon": "-75.13755",
+      "parks": {
+        "park_1_name": "Test 1",
+        "park_1_street": "Test 1 Street",
+        "park_2_name": "Test 2",
+        "park_2_street": "Test 2 Street",
+        "park_3_name": "Test 3",
+        "park_3_street": "Test 3 Street"
+      }
     }
   }
 }

--- a/spec/fixtures/property_2.json
+++ b/spec/fixtures/property_2.json
@@ -3,16 +3,17 @@
     "type": "property",
     "id": "2",
     "attributes": {
-        "street": "456 Center Street",
-        "city": "Philadelphia",
-        "state": "PA",
-        "zip": "19148",
-        "walk_score": "55",
-        "transit_score": "97",
-        "bike_score": "73",
-        "safety_score": "65",
-        "lat": "39.96246",
-        "lon": "-75.13755"
+      "street": "456 Center Street",
+      "city": "Philadelphia",
+      "state": "PA",
+      "zip": "19148",
+      "walk_score": "55",
+      "transit_score": "97",
+      "bike_score": "73",
+      "safety_score": "65",
+      "lat": "39.96246",
+      "lon": "-75.13755",
+      "parks": {}
     }
   }
 }


### PR DESCRIPTION
## Changes
- This PR closes #61 and closes #55 
- Adds display for 3 nearby parks and their addresses to the Property Show Page
- Styling updates on Property Show page to format the addresses and header and "more info" text for that feature
- Minor styling updates to the map, including removing the box border and changing the color of the marker to match our site (blue vs black)
- Update tests and fixture files to reflect changes
- Wording change on landing page, and adjusting text to reflect this

## Type of Changes
- [x] new feature
- [ ] setup
- [x] chore
- [ ] bug fix
- [ ] refactor
- [ ] other: 

## Checklist
- [x] Tests added for new functionality
- [x] All other tests are also passing (please note if not) 
  - Current coverage %: 98.5%

## Number of reviewers
- [x] 1
- [ ] 2
- [ ] 3

## Emoji or GIF about how you feel rn (optional)

